### PR TITLE
Deployment: Smithery config

### DIFF
--- a/src/puppeteer/README.md
+++ b/src/puppeteer/README.md
@@ -1,4 +1,5 @@
 # Puppeteer
+[![smithery badge](https://smithery.ai/badge/@smithery-ai/puppeteer)](https://smithery.ai/server/@smithery-ai/puppeteer)
 
 A Model Context Protocol server that provides browser automation capabilities using Puppeteer. This server enables LLMs to interact with web pages, take screenshots, and execute JavaScript in a real browser environment.
 
@@ -64,6 +65,14 @@ The server provides access to two types of resources:
 
 ## Configuration to use Puppeteer Server
 Here's the Claude Desktop configuration to use the Puppeter server:
+
+### Installing via Smithery
+
+To install Puppeteer Browser for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@smithery-ai/puppeteer):
+
+```bash
+npx -y @smithery/cli install @smithery-ai/puppeteer --client claude
+```
 
 ### Docker
 

--- a/src/puppeteer/smithery.yaml
+++ b/src/puppeteer/smithery.yaml
@@ -1,0 +1,15 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+build:
+  dockerBuildPath: ../../
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required: []
+    properties: {}
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    () => ({command:'docker',args:['run','-i','--rm','--init','-e','DOCKER_CONTAINER=true','mcp/puppeteer']})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@smithery-ai/puppeteer?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂