### PR TITLE
Deployment: Smithery config

### DIFF
--- a/src/google-maps/README.md
+++ b/src/google-maps/README.md
@@ -1,5 +1,7 @@
 # Google Maps MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@smithery-ai/google-maps)](https://smithery.ai/server/@smithery-ai/google-maps)
+
 MCP Server for the Google Maps API.
 
 ## Tools
@@ -99,6 +101,14 @@ Add the following to your `claude_desktop_config.json`:
     }
   }
 }
+```
+
+### Installing via Smithery
+
+To install Google Maps MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@smithery-ai/google-maps):
+
+```bash
+npx -y @smithery/cli install @smithery-ai/google-maps --client claude
 ```
 
 ## Build

--- a/src/google-maps/smithery.yaml
+++ b/src/google-maps/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+build:
+  dockerBuildPath: ../../
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - googleMapsApiKey
+    properties:
+      googleMapsApiKey:
+        type: string
+        description: The API key for the Google Maps server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({command: 'node', args: ['dist/index.js'], env: {GOOGLE_MAPS_API_KEY: config.googleMapsApiKey}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@smithery-ai/google-maps?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂