### PR TITLE
Deployment: Smithery config

### DIFF
--- a/src/everything/README.md
+++ b/src/everything/README.md
@@ -1,5 +1,7 @@
 # Everything MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@smithery-ai/everything)](https://smithery.ai/server/@smithery-ai/everything)
+
 This MCP server attempts to exercise all the features of the MCP protocol. It is not intended to be a useful server, but rather a test server for builders of MCP clients. It implements prompts, tools, resources, sampling, and more to showcase MCP capabilities.
 
 ## Components
@@ -79,6 +81,14 @@ Resource features:
    - Returns: Multi-turn conversation with images
 
 ## Usage with Claude Desktop
+
+### Installing via Smithery
+
+To install Everything MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@smithery-ai/everything):
+
+```bash
+npx -y @smithery/cli install @smithery-ai/everything --client claude
+```
 
 Add to your `claude_desktop_config.json`:
 

--- a/src/everything/smithery.yaml
+++ b/src/everything/smithery.yaml
@@ -1,0 +1,15 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+build:
+  dockerBuildPath: ../../
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required: []
+    properties: {}
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    () => ({ command: 'node', args: ['dist/index.js'] })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@smithery-ai/everything?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂