### PR TITLE
Deployment: Smithery config

### DIFF
--- a/src/git/README.md
+++ b/src/git/README.md
@@ -1,5 +1,7 @@
 # mcp-server-git: A git MCP server
 
+[![smithery badge](https://smithery.ai/badge/@smithery-ai/git)](https://smithery.ai/server/@smithery-ai/git)
+
 ## Overview
 
 A Model Context Protocol server for Git repository interaction and automation. This server provides tools to read, search, and manipulate Git repositories via Large Language Models.
@@ -81,6 +83,14 @@ Please note that mcp-server-git is currently in early development. The functiona
    - Returns: Contents of the specified commit
 
 ## Installation
+
+### Installing via Smithery
+
+To install mcp-server-git for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@smithery-ai/git):
+
+```bash
+npx -y @smithery/cli install @smithery-ai/git --client claude
+```
 
 ### Using uv (recommended)
 

--- a/src/git/smithery.yaml
+++ b/src/git/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+build:
+  dockerBuildPath: src/git
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - repositoryPath
+    properties:
+      repositoryPath:
+        type: string
+        description: Path to the Git repository.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({command:'python', args:['-m', 'mcp_server_git', '--repository', config.repositoryPath]})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@smithery-ai/git?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂