### PR TITLE
Deployment: Smithery config

### DIFF
--- a/src/gdrive/README.md
+++ b/src/gdrive/README.md
@@ -1,5 +1,7 @@
 # Google Drive server
 
+[![smithery badge](https://smithery.ai/badge/@smithery-ai/gdrive)](https://smithery.ai/server/@smithery-ai/gdrive)
+
 This MCP server integrates with Google Drive to allow listing, reading, and searching over files.
 
 ## Components
@@ -35,6 +37,14 @@ The server provides access to Google Drive files:
 7. Rename the key file to `gcp-oauth.keys.json` and place into the root of this repo (i.e. `servers/gcp-oauth.keys.json`)
 
 Make sure to build the server with either `npm run build` or `npm run watch`.
+
+### Installing via Smithery
+
+To install Google Drive for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@smithery-ai/gdrive):
+
+```bash
+npx -y @smithery/cli install @smithery-ai/gdrive --client claude
+```
 
 ### Authentication
 

--- a/src/gdrive/smithery.yaml
+++ b/src/gdrive/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+build:
+  dockerBuildPath: ../../
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - gcpOauthKeysFilePath
+    properties:
+      gcpOauthKeysFilePath:
+        type: string
+        description: Path to your Google Cloud Platform OAuth keys JSON file.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command:'docker', args:['run', '-i', '--rm', '--mount', `type=bind,source=${config.gcpOauthKeysFilePath},target=/gcp-oauth.keys.json`, '-v', 'mcp-gdrive:/gdrive-server', '-e', 'GDRIVE_OAUTH_PATH=/gcp-oauth.keys.json', '-e', 'GDRIVE_CREDENTIALS_PATH=/gdrive-server/credentials.json', '-p', '3000:3000', 'mcp/gdrive']})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@smithery-ai/gdrive?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂